### PR TITLE
Ignore quick-xml DoS advisories in audit; move to rustsec/audit-check

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -20,7 +20,11 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/audit-check@v1
+      - uses: rustsec/audit-check@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # quick-xml < 0.41 DoS advisories reached via urdf-rs; no urdf-rs
+          # release with a patched quick-xml exists yet. URDF input is local
+          # and trusted. Drop once urdf-rs ships with quick-xml >= 0.41.
+          ignore: RUSTSEC-2026-0194,RUSTSEC-2026-0195
 

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      # Cargo.lock is not committed; audit-check@v2 requires one to exist
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile
       - uses: rustsec/audit-check@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The nightly `audit` workflow (and therefore every PR, including #45) has been failing since Aug 5 on two RUSTSEC advisories against `quick-xml` 0.36.2:

- [RUSTSEC-2026-0194](https://rustsec.org/advisories/RUSTSEC-2026-0194.html) — quadratic attribute duplicate check (CPU DoS)
- [RUSTSEC-2026-0195](https://rustsec.org/advisories/RUSTSEC-2026-0195.html) — unbounded namespace allocation in `NsReader` (memory DoS)

Both are patched only in `quick-xml >= 0.41.0`. `quick-xml` is reached solely via `urdf-rs 0.9.0` (`quick-xml v0.36.2 └── urdf-rs v0.9.0`), whose latest release pins 0.36 and whose master is still on 0.39 — so there is nothing to bump on our side yet. Both advisories are denial-of-service only, and URDF files parsed here are local, user-supplied input, not untrusted remote XML.

This PR:
- ignores the two advisories in the audit check, with a comment to drop the ignores once urdf-rs ships with quick-xml >= 0.41
- replaces the archived `actions-rs/audit-check@v1` with its maintained successor `rustsec/audit-check@v2.0.0` (which provides the `ignore` input and fixes the Node 20 deprecation warning)

After merging, re-running the checks on #45 should make it green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)